### PR TITLE
Add NoBuild option to MigrationsScript

### DIFF
--- a/src/Cake.DotNetCoreEf.UnitTests/Unit/Migration/DotNetCoreEfMigrationScripterTests.cs
+++ b/src/Cake.DotNetCoreEf.UnitTests/Unit/Migration/DotNetCoreEfMigrationScripterTests.cs
@@ -91,11 +91,12 @@ namespace Cake.DotNetCoreEf.Tests.Unit.Migration
             fixture.Settings.To = "201702062048_Migration";
             fixture.Settings.Configuration = "release";
             fixture.Settings.MsBuildProjectExtensionsPath = "test-obj";
+            fixture.Settings.NoBuild = true;
             // When
             var result = fixture.Run();
 
             // Then
-            Assert.Equal("ef migrations script \"201702062047_Migration\" \"201702062048_Migration\" --configuration \"release\" --msbuildprojectextensionspath \"test-obj\" --context \"CakeContext\"", result.Args);
+            Assert.Equal("ef migrations script \"201702062047_Migration\" \"201702062048_Migration\" --configuration \"release\" --msbuildprojectextensionspath \"test-obj\" --context \"CakeContext\" --no-build", result.Args);
         }
     }
 }

--- a/src/Cake.DotNetCoreEf/Migration/DotNetCoreEfMigrationScriptSettings.cs
+++ b/src/Cake.DotNetCoreEf/Migration/DotNetCoreEfMigrationScriptSettings.cs
@@ -35,5 +35,11 @@ namespace Cake.DotNetCoreEf.Migration
         /// The DbContext to use. If omitted, the default DbContext is used.
         /// </summary>
         public string Context { get; set; }
+        
+        /// <summary>
+        /// Gets or sets a value indicating whether to not to build the project before publishing.
+        /// This makes build faster, but requires build to be done before publish is executed. 
+        /// </summary>
+        public bool NoBuild { get; set; }
     }
 }

--- a/src/Cake.DotNetCoreEf/Migration/DotNetCoreEfMigrationScripter.cs
+++ b/src/Cake.DotNetCoreEf/Migration/DotNetCoreEfMigrationScripter.cs
@@ -88,6 +88,11 @@ namespace Cake.DotNetCoreEf.Migration
                 builder.Append("--idempotent");
             }
 
+            if (settings.NoBuild)
+            {
+                builder.Append("--no-build");
+            }
+
             // Arguments
             if (!arguments.IsNullOrEmpty())
             {


### PR DESCRIPTION
Fixes #39

Allows you to script migrations without building projects